### PR TITLE
fix body height

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -5,7 +5,7 @@ table, form, input, td, th, p, textarea, select {
 
 body {
     background: #fff;
-    height: 850px;
+    height: 100%;
 }
 
 #page-body {


### PR DESCRIPTION
the body height should not be a hardwired value as this will overflow if more than expected content appears.

In the main page, if the sidebar including executors etc is more than the hardwired 850px, the body overflows. Same goes for job pages where many builds are displayed
