### PR TITLE
Set side panel to be relatively-positioned, so footer will stay at bottom of page.

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -497,7 +497,7 @@ tr.permission-row:nth-child(even) {
     background-image: radial-gradient(circle at 3px 3px, #f0ad4e 0%, #d58512 100%);
 }
 
-
-
-
+.fixedGridLayout #side-panel {
+    position: relative;
+}
 


### PR DESCRIPTION
We ran into a problem where, with many builds in the build list on the left panel (`#side-panel`), it could exceed the height of the main page content (`#page-body`), causing the footer to ride up the page like so:

<img width="1157" alt="screen shot 2015-10-26 at 3 28 48 pm" src="https://cloud.githubusercontent.com/assets/314663/10740571/532eb652-7bf9-11e5-9e6f-3ccbdd3c741d.png">

I'm no CSS guru, but this change seemed to fix it. (Chrome seemed to infer `position: absolute;` even though it's not set anywhere.)