### PR TITLE
Don't fix height of `.login-wrapper`

### DIFF
--- a/src/login.css
+++ b/src/login.css
@@ -39,7 +39,7 @@ input[name='j_username'], input[name='j_password'] {
 	border: solid #ccc;
 	border-width: 1px;
 	border-radius: 4px;
-	height: 250px;
+	min-height: 250px;
 	background-color: #fff;
 }
 


### PR DESCRIPTION
Jenkins allows users to log with *Federated login service*. If this option is enabled, additional elements are rendered bellow standard login form. If `height` is fixed, then there's not enough space for elements and they flow out of `.login-wrapper`.
