### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ And you can find the files at:
 
 If you are experiencing issues please let me know! Also, feel free to contribute!
 
-##Thanks to
+## Thanks to
 - [JQuery Plugin][jquery] for the jQuery plugin
 - [Simple Theme Plugin][simple] for the Simple Theme plugin
 - [Atlassian][atlassian] for the the design inspiration and for making awesome products


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
