### PR TITLE
Fix width on #jenkins-home-link anchor

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -92,6 +92,10 @@ a:hover, a:active {
     display: none;
 }
 
+.logo a#jenkins-home-link {
+    width: inherit;
+}
+
 #search-box {
     width: 175px !important;
     -moz-appearance: textfield;


### PR DESCRIPTION
Width on `.logo a#jenkins-home-link` ends up with the same of 40px in height and 0px in width, thus making this link useless.

This fix extends anchor width to that of `.logo` placeholder div. Link ends up larger than actual image, but I don't know how to elegantly calculate width with only CSS.

Here is example with fix applied:
![jenkins-link](https://user-images.githubusercontent.com/1444439/71122144-d39a2000-21d7-11ea-94ae-c5cab730bbe9.png)
